### PR TITLE
fix: make getGamesForGuild to return games

### DIFF
--- a/pkg/storage/postgres.go
+++ b/pkg/storage/postgres.go
@@ -420,7 +420,7 @@ func getGamesForGuild(conn PgxIface, guildID uint64) ([]*PostgresGame, error) {
 	if err != nil {
 		return nil, err
 	}
-	return nil, nil
+	return games, nil
 }
 
 func (psqlInterface *PsqlInterface) GetGamesEventsForGuild(guildID uint64) ([]*PostgresGameEvent, error) {


### PR DESCRIPTION
`getGamesForGuild` always returns nothing (causes generating empty CSV), so make it to return `games`.